### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
 Wiegand KEYWORD1
 initialize KEYWORD2
-avail KEYWORD3
-dequeue_buf KEYWORD4
+avail KEYWORD2
+dequeue_buf KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
-Wiegand KEYWORD1
-initialize KEYWORD2
-avail KEYWORD2
-dequeue_buf KEYWORD2
+Wiegand	KEYWORD1
+initialize	KEYWORD2
+avail	KEYWORD2
+dequeue_buf	KEYWORD2


### PR DESCRIPTION
- Use correct and valid KEYWORD_TOKENTYPEs
- Use correct field separator

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords